### PR TITLE
workflows/qubes-dom0-package*.yml: bump action versions

### DIFF
--- a/.github/workflows/qubes-dom0-package.yml
+++ b/.github/workflows/qubes-dom0-package.yml
@@ -42,18 +42,18 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 100 # need history for `git format-patch`
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: TrenchBoot/.github
           path: shared
           ref: ${{ github.job_workflow_sha }}
 
       - name: Cache Docker image and dom0 stuff
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: docker-cache
         with:
           path: |
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build Docker image (optional)
         if: steps.docker-cache.outputs.cache-hit != 'true'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           tags: qubes-fedora-builder:latest
           context: shared/qubes-builder-docker
@@ -99,7 +99,7 @@ jobs:
                      qubes-fedora-builder:latest
 
       - name: Save built packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qubesos.dom0.fc37-${{ inputs.qubes-component }}-${{ github.sha }}
           path: '*.rpm'

--- a/.github/workflows/qubes-dom0-packagev2.yml
+++ b/.github/workflows/qubes-dom0-packagev2.yml
@@ -31,12 +31,12 @@ jobs:
           createrepo-c devscripts docker python3-docker reprepro \
           python3-pathspec mktorrent python3-lxml python3-dateutil
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: QubesOS/qubes-builderv2
 
       - name: Cache Docker image and dom0 stuff
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: docker-cache
         with:
           path: |
@@ -151,7 +151,7 @@ jobs:
           cp --verbose "${rpms[@]}" .
 
       - name: Save built packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: qubesos.dom0.fc37-${{ inputs.qubes-component }}-${{ github.sha }}


### PR DESCRIPTION
Node 16 is being deprecated [1] on GitHub Actions. Update actions to versions that use Node 20.

[1]: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Example PR for builder v1: https://github.com/TrenchBoot/grub/actions/runs/7678752537/job/20928947804?pr=16 (building currently, hopefully will be successful)