### PR TITLE
workflows/qubes-dom0-package*.yml: bump release-action to v1.14.0

### DIFF
--- a/.github/workflows/qubes-dom0-package.yml
+++ b/.github/workflows/qubes-dom0-package.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Create release for a new tag
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
-        uses: ncipollo/release-action@v1.13.0
+        uses: ncipollo/release-action@v1.14.0
         with:
           artifacts: '*.rpm'
           artifactErrorsFailBuild: true

--- a/.github/workflows/qubes-dom0-packagev2.yml
+++ b/.github/workflows/qubes-dom0-packagev2.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Create release for a new tag
         if: github.event_name == 'push' && github.ref_type == 'tag'
-        uses: ncipollo/release-action@v1.13.0
+        uses: ncipollo/release-action@v1.14.0
         with:
           artifacts: '*.rpm'
           artifactErrorsFailBuild: true


### PR DESCRIPTION
This avoids Node 16 deprecation warning, such as
https://github.com/TrenchBoot/grub/actions/runs/9063115259?pr=20