### PR TITLE
qubes-builder-docker/builder.conf: Switch to release4.2 branch for co…

### DIFF
--- a/qubes-builder-docker/builder.conf
+++ b/qubes-builder-docker/builder.conf
@@ -3,7 +3,7 @@ RELEASE := 4.2
 SSH_ACCESS  := 0
 GIT_BASEURL := https://github.com
 GIT_PREFIX  := QubesOS/qubes-
-BRANCH      ?= main
+BRANCH      ?= release4.2
 
 # Fetch repositories with depth=1
 GIT_CLONE_FAST ?= 1


### PR DESCRIPTION
…mponents

Qubes OS switched to use release4.2 branch for building components. As our released packages were for Qubes OS R4.2, to keep them building properly, change the default branch to release4.2.