### PR TITLE
qubes-dom0-packagev2.yml: use qubes-os-main.yml as a base

### DIFF
--- a/.github/workflows/qubes-dom0-packagev2.yml
+++ b/.github/workflows/qubes-dom0-packagev2.yml
@@ -71,10 +71,9 @@ jobs:
           branch: ${{ github.head_ref }}
           tag: ${{ github.ref_name }}
         run: |
-          cp example-configs/builder-devel.yml builder.yml
-          sed -i "s#^  prefix: fepitre/qubes-#  prefix: QubesOS/qubes-#" builder.yml
-          sed -i "s#^  branch: builderv2#  branch: main#" builder.yml
-          sed -i "s#^artifacts-dir: .*#artifacts-dir: $PWD/artifacts#" builder.yml
+          cp example-configs/qubes-os-main.yml builder.yml
+          sed -i "s#^  type: qubes#  type: docker#" builder.yml
+          sed -i "s#^    dispvm: \"@dispvm\"#    image: \"qubes-builder-fedora:latest\"#" builder.yml
 
           branch_name=${${{ github.ref_type }}}
           if [ -z "$branch_name" ]; then

--- a/qubes-builder-docker/builder.conf
+++ b/qubes-builder-docker/builder.conf
@@ -3,7 +3,7 @@ RELEASE := 4.2
 SSH_ACCESS  := 0
 GIT_BASEURL := https://github.com
 GIT_PREFIX  := QubesOS/qubes-
-BRANCH      ?= release4.2
+BRANCH      := main
 
 # Fetch repositories with depth=1
 GIT_CLONE_FAST ?= 1
@@ -69,6 +69,7 @@ BRANCH_python_fido2 = main
 BRANCH_python_qasync = master
 BRANCH_python_panflute = master
 BRANCH_intel_microcode = master
+BRANCH_vmm_xen = main
 
 BRANCH_efitools = main
 BRANCH_sbsigntools = main


### PR DESCRIPTION
Previously used builder-devel.yml has been removed. It wasn't supposed to be used in the first place.