### PR TITLE
Fixes for v2 builder

### DIFF
--- a/.github/workflows/qubes-dom0-packagev2.yml
+++ b/.github/workflows/qubes-dom0-packagev2.yml
@@ -13,6 +13,11 @@ on:
           Relative path to directory containing Qubes OS package.
         required: false
         type: string
+      qubes-pkg-revision:
+        description: >
+          Forced revision of a package.
+        required: false
+        type: string
       qubes-pkg-version:
         description: >
           Forced version of a package.
@@ -72,6 +77,7 @@ jobs:
           URL: ${{ github.repositoryUrl }}
           COMPONENT: ${{ inputs.qubes-component }}
           PKG_DIR: ${{ inputs.qubes-pkg-src-dir }}
+          PKG_REV: ${{ inputs.qubes-pkg-revision }}
           PKG_VER: ${{ inputs.qubes-pkg-version }}
           # Following 2 variables are used in double expansion '${${{ github.ref_type }}}',
           # do not change these names even though they don't follow the convention.
@@ -115,11 +121,16 @@ jobs:
               # Temporary file handles case when qubes-pkg-src-dir is set to '.'
               mv "$clone_dir/$COMPONENT.spec.in.tmp" "$clone_dir/$COMPONENT.spec.in"
 
-              echo 1 > "$clone_dir/rel"
+              if [ -z "$PKG_REV" ]; then
+                  PKG_REV=1
+              fi
+              echo "$PKG_REV" > "$clone_dir/rel"
+
               if [ -z "$PKG_VER" ]; then
                   PKG_VER="0+$(git -C "$clone_dir" show-ref -s "$branch_name" | head -1)"
               fi
               echo "$PKG_VER" > "$clone_dir/version"
+
               cat > "$clone_dir/.qubesbuilder" <<EOF
               host:
                 rpm:

--- a/.github/workflows/qubes-dom0-packagev2.yml
+++ b/.github/workflows/qubes-dom0-packagev2.yml
@@ -70,7 +70,7 @@ jobs:
           branch: ${{ github.head_ref }}
           tag: ${{ github.ref_name }}
         run: |
-          cp example-configs/qubes-os-main.yml builder.yml
+          cp example-configs/qubes-os-r4.2.yml builder.yml
           # Switch from Qubes to Docker executor
           sed -i "/^executor:$/,+4d; /^#executor:$/,+3s/#//" builder.yml
 

--- a/.github/workflows/qubes-dom0-packagev2.yml
+++ b/.github/workflows/qubes-dom0-packagev2.yml
@@ -160,6 +160,18 @@ jobs:
               sed -i "/^  - $COMPONENT:/a\      verification-mode: insecure-skip-checking" builder.yml
               sed -i "/^  - $COMPONENT:/a\      branch: $branch_name" builder.yml
               sed -i "/^  - $COMPONENT:/a\      url: /builder/$rel_clone_dir" builder.yml
+
+              echo "::group::version"
+              cat $clone_dir/version
+              echo "::endgroup::"
+
+              echo "::group::$COMPONENT.spec.in"
+              cat $clone_dir/$COMPONENT.spec.in
+              echo "::endgroup::"
+
+              echo "::group::.qubesbuilder"
+              cat $clone_dir/.qubesbuilder
+              echo "::endgroup::"
           else
               # It's an existing component that needs some overrides
               sed -i "1,/^  - $COMPONENT/s#^  - $COMPONENT#&:#" builder.yml
@@ -170,18 +182,6 @@ jobs:
 
           echo "::group::builder.yml"
           cat builder.yml
-          echo "::endgroup::"
-
-          echo "::group::version"
-          cat $clone_dir/version
-          echo "::endgroup::"
-
-          echo "::group::$COMPONENT.spec.in"
-          cat $clone_dir/$COMPONENT.spec.in
-          echo "::endgroup::"
-
-          echo "::group::.qubesbuilder"
-          cat $clone_dir/.qubesbuilder
           echo "::endgroup::"
 
       - name: Build and package

--- a/.github/workflows/qubes-dom0-packagev2.yml
+++ b/.github/workflows/qubes-dom0-packagev2.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: QubesOS/qubes-builderv2
+          ref: 80dd898cc0472dd99f161f1d1c7c44da64de93f2
+          fetch-depth: 0
 
       - name: Cache Docker image and dom0 stuff
         uses: actions/cache@v4

--- a/.github/workflows/qubes-dom0-packagev2.yml
+++ b/.github/workflows/qubes-dom0-packagev2.yml
@@ -13,6 +13,11 @@ on:
           Relative path to directory containing Qubes OS package.
         required: false
         type: string
+      qubes-pkg-version:
+        description: >
+          Forced version of a package.
+        required: false
+        type: string
 
 jobs:
   build-and-package:
@@ -67,6 +72,7 @@ jobs:
           URL: ${{ github.repositoryUrl }}
           COMPONENT: ${{ inputs.qubes-component }}
           PKG_DIR: ${{ inputs.qubes-pkg-src-dir }}
+          PKG_VER: ${{ inputs.qubes-pkg-version }}
           # Following 2 variables are used in double expansion '${${{ github.ref_type }}}',
           # do not change these names even though they don't follow the convention.
           branch: ${{ github.head_ref }}
@@ -110,8 +116,10 @@ jobs:
               mv "$clone_dir/$COMPONENT.spec.in.tmp" "$clone_dir/$COMPONENT.spec.in"
 
               echo 1 > "$clone_dir/rel"
-              echo "0+$(git -C "$clone_dir" show-ref -s "$branch_name" | head -1)" \
-                  > "$clone_dir/version"
+              if [ -z "$PKG_VER" ]; then
+                  PKG_VER="0+$(git -C "$clone_dir" show-ref -s "$branch_name" | head -1)"
+              fi
+              echo "$PKG_VER" > "$clone_dir/version"
               cat > "$clone_dir/.qubesbuilder" <<EOF
               host:
                 rpm:

--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ package, hence significantly reduced set of parameters.
 There is also no need to use `qubes-builder-docker/` in this case because
 builder's repository contains its own Docker image.
 
-| Parameter           | Type   | Req. | Def. | Description
-| ---------           | ----   | ---- | ---- | -----------
-| `qubes-component`   | string | Yes  | -    | Name of QubesOS component as recognized by its build system.
-| `qubes-pkg-src-dir` | string | No   | -    | Relative path to directory containing Qubes OS package.
-| `qubes-pkg-version` | string | No   | auto | Version for RPM packages
+| Parameter            | Type   | Req. | Def. | Description
+| ---------            | ----   | ---- | ---- | -----------
+| `qubes-component`    | string | Yes  | -    | Name of QubesOS component as recognized by its build system.
+| `qubes-pkg-src-dir`  | string | No   | -    | Relative path to directory containing Qubes OS package.
+| `qubes-pkg-version`  | string | No   | auto | Version for RPM packages
+| `qubes-pkg-revision` | string | No   | `1`  | Revision for RPM packages
 
 Used by [TrenchBoot/qubes-antievilmaid][aem] and
 [TrenchBoot/secure-kernel-loader][skl].  The latter makes use of

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ builder's repository contains its own Docker image.
 | ---------           | ----   | ---- | ---- | -----------
 | `qubes-component`   | string | Yes  | -    | Name of QubesOS component as recognized by its build system.
 | `qubes-pkg-src-dir` | string | No   | -    | Relative path to directory containing Qubes OS package.
+| `qubes-pkg-version` | string | No   | auto | Version for RPM packages
 
 Used by [TrenchBoot/qubes-antievilmaid][aem] and
 [TrenchBoot/secure-kernel-loader][skl].  The latter makes use of


### PR DESCRIPTION
* Clone the builder at a specific commit which works at the moment
* Configure the builder for Qubes OS 4.2
* Fix use of builder without setting `qubes-pkg-src-dir` workflow parameter
* Allow setting pre-defined package version and revision