### PR TITLE
workflows: rebase.yml: don't pass empty additional-params as arg

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -99,6 +99,13 @@ jobs:
           ADDITIONAL_PARAMS: ${{ inputs.additional-params }}
         run: |
           set +e
+          # Split ADDITIONAL_PARAMS into separate arguments. Quoting an empty
+          # value would forward it as a spurious 5th positional argument and
+          # the script rejects anything other than exactly four.
+          ADDITIONAL_ARGS=()
+          if [ -n "$ADDITIONAL_PARAMS" ]; then
+              read -ra ADDITIONAL_ARGS <<< "$ADDITIONAL_PARAMS"
+          fi
           shared/scripts/rebase.sh --first-remote-token "$FIRST_REMOTE_TOKEN" \
           --commit-user-name "$NAME" \
           --commit-user-email "$EMAIL" \
@@ -108,7 +115,7 @@ jobs:
           "$DOWNSTREAM_BRANCH" \
           "$UPSTREAM_REPO" \
           "$UPSTREAM_BRANCH" \
-          "$ADDITIONAL_PARAMS"
+          "${ADDITIONAL_ARGS[@]}"
           rc=$?
           echo "exit-code=${rc}" >> "$GITHUB_OUTPUT"
           # The "No rebase needed" return code should be considered a success


### PR DESCRIPTION
When a caller leaves additional-params unset, the quoted "$ADDITIONAL_PARAMS" was forwarded as an empty fifth positional argument. rebase.sh requires exactly four, so it printed usage and exited 1. Collect the value into an array so an empty string adds no argument while multiple flags still split correctly.

I updated the `v2` tag, test: https://github.com/TrenchBoot/qubes-antievilmaid/actions/runs/28433743091/job/84254492534